### PR TITLE
Fix bug in tile defs computation

### DIFF
--- a/main.go
+++ b/main.go
@@ -363,8 +363,8 @@ func (l *Layer) TileDefs(tss []TileSet) (tds []*TileDef, err error) {
 			if bid < uint32(t.FirstGlobalID) {
 				break
 			}
-
-			ts = &t
+			currTs := t
+			ts = &currTs
 		}
 
 		// if we never found a tileset, the file is invalid; return an error that


### PR DESCRIPTION
Reference to loop variable pointed to wrong object after the loop (since there's one extra iteration). A good fix would be to replace TileSet with *TileSet everywhere in the code (and do the same for layers, object groups, et cetera et cetera), but that'll take some time.