### PR TITLE
Fix handling of multiple tilesets.

### DIFF
--- a/main.go
+++ b/main.go
@@ -361,12 +361,13 @@ func (l *Layer) TileDefs(tss []TileSet) (tds []*TileDef, err error) {
 		}
 
 		var ts *TileSet
-		for _, t := range tss {
+		for i := range tss {
+			t := &tss[i]
 			if bid < uint32(t.FirstGlobalID) {
 				break
 			}
 
-			ts = &t
+			ts = t
 		}
 
 		// if we never found a tileset, the file is invalid; return an error that


### PR DESCRIPTION
The previous code associated all tiles to the highest-numbered tileset, making the TileDefs of tiles from any other tileset invalid (and with a huge uint32 tile index).